### PR TITLE
Fix Windows notification badge count

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -283,7 +283,7 @@ function updateNotifications(app) {
     let sum = 0;
 
     // Query the dom for the notification badges
-    win.webContents.executeJavaScript(`Array.from(document.querySelectorAll('.gv_root .navListItem .navItemBadge')).map(n => n.textContent && n.textContent.trim());`).then(counts => {
+    win.webContents.executeJavaScript(`Array.from(document.querySelectorAll('.mat-sidenav-content .navListItem:not(mat-divider~.navListItem) .navItemBadge')).map(n => n.textContent && n.textContent.trim());`).then(counts => {
         if (counts && counts.length > 0) {
             sum = counts.reduce((accum, count) => {
                 try {
@@ -329,6 +329,7 @@ function processNotificationCount(app, count) {
             processNotificationCount_MacOS(app, oldCount, count);
         }
         else if (isWindows()) {
+
             processNotificationCount_Windows(oldCount, count);
         }
         

--- a/src/main.js
+++ b/src/main.js
@@ -329,7 +329,6 @@ function processNotificationCount(app, count) {
             processNotificationCount_MacOS(app, oldCount, count);
         }
         else if (isWindows()) {
-
             processNotificationCount_Windows(oldCount, count);
         }
         


### PR DESCRIPTION
Fixes two issues with the Windows taskbar icon notification badge count:
  - The number for the notification was doubled from the actual count
  - Any unread messages in Spam were included in the notification count

The first issue was solved by changing the root selector for the dom query from `.gv_root` to `.mat_sidenav-content` since there were two sets of nav items with the unread counts in the app, and we only need to count one of them.

The second was solved by ignoring the `.navListItem`s that come *after* the divider in the sidebar - this currently excludes *both* Spam and Archive - I expect excluding Archive is also acceptable since I suspect if there ever were to be unread messages in Archive a user wouldn't expect to have a notification about it.

I have only tested this in Windows.