### PR TITLE
Updating badge count css hierarchy check for latest app change

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -283,7 +283,7 @@ function updateNotifications(app) {
     let sum = 0;
 
     // Query the dom for the notification badges
-    win.webContents.executeJavaScript(`Array.from(document.querySelectorAll('.mat-sidenav-content .navListItem:not(mat-divider~.navListItem) .navItemBadge')).map(n => n.textContent && n.textContent.trim());`).then(counts => {
+    win.webContents.executeJavaScript(`Array.from(document.querySelectorAll('.mat-sidenav-content .navListItem:not(.menuDivider~.navListItem) .navItemBadge')).map(n => n.textContent && n.textContent.trim());`).then(counts => {
         if (counts && counts.length > 0) {
             sum = counts.reduce((accum, count) => {
                 try {


### PR DESCRIPTION
A recent app update from Google changed some of the css classes used in the nav bar, which caused unread messages from Archive and Spam to once again show up in the icon notification badge count. 

This PR updates the logic to once again ignore unread messages after the menu divider when determining the icon badge number.