### PR TITLE
Add simple unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "build:x64": "electron-builder --mac --windows --linux --x64",
   "build:arm64": "electron-builder --mac --windows --linux --arm64",
   "release": "electron-builder --mac --windows --linux --x64 --arm64 --publish always"
+  ,"test": "node test/run-tests.js"
  },
  "keywords": [
   "electron",

--- a/src/utils/cssInjector.js
+++ b/src/utils/cssInjector.js
@@ -1,4 +1,4 @@
-const sass = require('sass');
+let sass;
 const fs = require('fs');
 const path = require('path');
 
@@ -6,7 +6,7 @@ const BASE = `base.scss`;
 const MAPPINGS = `mappings.scss`;
 const HIDE_DIALER_SIDEBAR_CSS = `gv-call-sidebar { display: none }`;
 
-module.exports = class Injector {
+class Injector {
     constructor(app, win) {
         this.win = win;
         this.app = app;
@@ -27,6 +27,9 @@ module.exports = class Injector {
     }
 
     injectTheme(theme) {
+        if (!sass) {
+            sass = require('sass');
+        }
         if (this.styleKey) {
             this.win.webContents.removeInsertedCSS(this.styleKey);
             this.styleKey = null;
@@ -50,6 +53,9 @@ module.exports = class Injector {
         }
     }
 }
+
+module.exports = Injector;
+module.exports.joinImports = joinImports;
 
 /**
  * The way sass processes use functions just isn't good enough, we need variables that can scope across files and we also

--- a/test/constants.test.js
+++ b/test/constants.test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const constants = require('../src/constants');
+
+assert.strictEqual(constants.APPLICATION_NAME, 'Voice Desktop');
+assert.strictEqual(constants.URL_GOOGLE_VOICE, 'https://voice.google.com');
+assert.strictEqual(constants.DEFAULT_SETTING_SHOW_MENU_BAR, true);
+
+console.log('constants test passed');

--- a/test/joinImports.test.js
+++ b/test/joinImports.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const { joinImports } = require('../src/utils/cssInjector');
+
+const app = { getAppPath: () => path.join(__dirname, '..') };
+const themeFile = fs.readFileSync(path.join(app.getAppPath(), 'src', 'themes', 'demo.scss'), 'utf-8');
+const result = joinImports(app, themeFile);
+
+assert(result.includes('Dont use !important'), 'base.scss content missing');
+assert(result.includes('These mappings may seem'), 'mappings.scss content missing');
+
+console.log('joinImports test passed');

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,0 +1,3 @@
+require('./constants.test');
+require('./joinImports.test');
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add a `test` script to `package.json`
- export `joinImports` in `cssInjector` and lazy load `sass`
- create basic tests for constants and the joinImports helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f6581b18832685ba62b50f1fea02